### PR TITLE
auto load new datasets on startup

### DIFF
--- a/reporting/config/services/superset/datasources/database.yaml
+++ b/reporting/config/services/superset/datasources/database.yaml
@@ -1055,3 +1055,92 @@ databases:
     - {expression: COUNT(*), metric_name: count, metric_type: count, verbose_name: COUNT(*)}
     schema: public
     table_name: kafka_stock_events
+  - columns:
+    - {column_name: occurreddate, is_dttm: true, type: TIMESTAMP WITH TIME ZONE}
+    - {column_name: Facility Type, filterable: true, groupby: true, type: TEXT}
+    - {column_name: Product, filterable: true,groupby: true, type: TEXT}
+    - {column_name: isphysicalinventory,type: TEXT}
+    - {column_name: Facility, filterable: true, groupby: true, type: TEXT}
+    - {column_name: District, filterable: true, groupby: true, type: TEXT}
+    - {column_name: Ownership, filterable: true, groupby: true, type: TEXT}
+    - {column_name: Program, filterable: true, groupby: true, type: TEXT}
+    - {column_name: Batch Number, filterable: true, groupby: true, type: TEXT}
+    - {column_name: quantity, type: DOUBLE PRECISION, sum: true, avg: true}
+    - {column_name: Reason, filterable: true, groupby: true, type: TEXT}
+    - {column_name: reasontype, filterable: true, groupby: true, type: TEXT}
+    - {column_name: debit_or_credit,expression: "CASE WHEN reasontype = 'CREDIT' THEN quantity   WHEN reasontype = 'DEBIT' THEN -quantity ELSE 0 END", type: DOUBLE PRECISION}
+    main_dttm_col: occurreddate
+    metrics:
+    - {expression: COUNT(*), metric_name: count, metric_type: count, verbose_name: COUNT(*)}
+    schema: public
+    table_name: dqa
+
+  - columns:
+    - { column_name: "OS Month", is_dttm: true, type: TIMESTAMP WITH TIME ZONE }
+    - { column_name: date_became_os, is_dttm: true, type: TIMESTAMP WITH TIME ZONE }
+    - { column_name: date_received_post_os, is_dttm: true, type: TIMESTAMP WITH TIME ZONE }
+    - { column_name: district, filterable: true, groupby: true, type: TEXT }
+    - { column_name: facility, filterable: true, groupby: true, type: TEXT }
+    - { column_name: facility_type, filterable: true, groupby: true, type: TEXT }
+    - { column_name: program, filterable: true, groupby: true, type: TEXT }
+    - { column_name: product, filterable: true, groupby: true, type: TEXT }
+    - { column_name: os_days, type: DOUBLE PRECISION, sum: true, avg: true }
+    - { column_name: was_service_interruption, filterable: true, groupby: true, type: TEXT }
+    main_dttm_col: "OS Month"
+    metrics:
+    - { expression: COUNT(*), metric_name: count, metric_type: count, verbose_name: COUNT(*) }
+    schema: public
+    table_name: stockouts
+  - columns:
+    - { column_name: District, filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Facility Name", filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Service Point", filterable: true, groupby: true, type: TEXT }
+    - { column_name: facility_code, filterable: true, groupby: true, type: TEXT }
+    - { column_name: facility_prefix, filterable: true, groupby: true, type: TEXT }
+    - { column_name: facility_type, filterable: true, groupby: true, type: TEXT }
+    - { column_name: facility_operator, filterable: true, groupby: true, type: TEXT }
+    - { column_name: program, filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Reporting Period",filterable: true, groupby: true, type: TEXT }
+    - { column_name: fullproductname, filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Quantity Requested", type: DOUBLE PRECISION, sum: true, avg: true }
+    - { column_name: status, filterable: true, groupby: true, type: TEXT }
+    metrics:
+    - { expression: COUNT(*), metric_name: count, metric_type: count, verbose_name: COUNT(*) }
+    schema: public
+    table_name: emergency_orders
+    
+  - columns:
+    - { column_name: "Date Received", is_dttm: true, type: TIMESTAMP WITH TIME ZONE }
+    - { column_name: "Issuing Facility", filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Issuing District", filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Issuing Facility Type", filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Issuing Facility Ownership", filterable: true, groupby: true, type: TEXT }
+    - { column_name: Program, filterable: true, groupby: true, type: TEXT }
+    - { column_name: Product, filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Batch Number", filterable: true, groupby: true, type: TEXT }
+    - { column_name: Quantity, type: DOUBLE PRECISION, sum: true, avg: true }
+    - { column_name: "Receiving Facility", filterable: true, groupby: true, type: TEXT }
+    - { column_name: District, filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Facility Type", filterable: true, groupby: true, type: TEXT }
+    - { column_name: Ownership, filterable: true, groupby: true, type: TEXT }
+    main_dttm_col: "Date Received"
+    metrics:
+    - { expression: COUNT(*), metric_name: count, metric_type: count, verbose_name: COUNT(*) }
+    schema: public
+    table_name: redistribution
+  - columns:
+    - { column_name: occurreddate, is_dttm: true, type: TIMESTAMP WITH TIME ZONE }
+    - { column_name: District, filterable: true, groupby: true, type: TEXT }
+    - { column_name: Facility, filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Facility Type", filterable: true, groupby: true, type: TEXT }
+    - { column_name: Ownership, filterable: true, groupby: true, type: TEXT }
+    - { column_name: Program, filterable: true, groupby: true, type: TEXT }
+    - { column_name: Product, filterable: true, groupby: true, type: TEXT }
+    - { column_name: "Batch Number", filterable: true, groupby: true, type: TEXT }
+    - { column_name: Quantity, type: DOUBLE PRECISION, sum: true, avg: true }
+    - { column_name: Reason, filterable: true, groupby: true, type: TEXT }
+    main_dttm_col: occurreddate
+    metrics:
+    - { expression: COUNT(*), metric_name: count, metric_type: count, verbose_name: COUNT(*) }
+    schema: public
+    table_name: product_loss

--- a/reporting/cron/periodic/15min/refresh-mv
+++ b/reporting/cron/periodic/15min/refresh-mv
@@ -70,7 +70,7 @@ psql <<-EOSQL
   \echo 'Refreshing stockouts'
   REFRESH MATERIALIZED VIEW stockouts;
 
-  \echo 'Refreshing priduct_loss'
+  \echo 'Refreshing product_loss'
   REFRESH MATERIALIZED VIEW product_loss;
 
   \echo 'Refreshing emergency_orders'


### PR DESCRIPTION
Create dqa, product_loss, emergency_orders, redistribution and stockouts datasets from their respective views when superset is starting up. 